### PR TITLE
Set queue mode to “Terminate previous script”

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -69,7 +69,7 @@
 				<key>queuedelaymode</key>
 				<integer>0</integer>
 				<key>queuemode</key>
-				<integer>1</integer>
+				<integer>2</integer>
 				<key>runningsubtext</key>
 				<string>Searching...</string>
 				<key>script</key>


### PR DESCRIPTION
This ensures that the user does not see results for previously typed arguments and only sees results for their currently typed argument. As explained in Alfred:

> For slow scripts, it may be better to terminate the previous script and instead, wait for the result for the most recently typed argument.